### PR TITLE
Fix baud rate documentation for Elk M1

### DIFF
--- a/source/_components/elkm1.markdown
+++ b/source/_components/elkm1.markdown
@@ -50,7 +50,7 @@ elkm1:
 
 {% configuration %}
 host:
-  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with.  You may have multiple host sections for connecting multiple controllers.
+  description: Connection string to Elk of the form `<method>://<address>[:port]`. `<method>` is `elk` for non-secure connection, `elks` for secure connection, and `serial` for serial port connection. `<address>` is IP address or domain or for `serial` the serial port that the Elk is connected to. Optional `<port>` is the port to connect to on the Elk, defaulting to 2101 for `elk` and 2601 for `elks`. For `serial` method, _address_ is the path to the tty _/dev/ttyS1_ for example and `[:baud]` is the baud rate to connect with (Elk systems default to 115200 baud, but this can be changed during system configuration).  You may have multiple host sections for connecting multiple controllers.
   required: true
   type: string
 username:
@@ -277,11 +277,11 @@ elkm1:
     exclude: [b12-d5]
 ```
 
-Example for a serial port instance on /dev/ttyS1 at 9600 baud:
+Example for a serial port instance on /dev/ttyS1 at 115200 baud:
 
 ```yaml
 elkm1:
-  host: serial://dev/ttyS1:9600
+  host: serial:///dev/ttyS1:115200
   username: USERNAME
   password: PASSWORD
   area:


### PR DESCRIPTION
**Description:**
Fix baud rate in example to match the default baud rate used by Elk M1 systems (if you choose the wrong baud rate, this component silently fails to connect).  Also add a missing / character.

**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [X ] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [X ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
